### PR TITLE
Fix VertexLoader crashing

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -487,7 +487,7 @@ void VertexLoaderX64::GenerateVertexLoader()
 	}
 	else
 	{
-		MOV(32, R(scratch1), M((u32*)&g_main_cp_state.matrix_index_a));
+		MOV(32, R(scratch1), MPIC(&g_main_cp_state.matrix_index_a));
 	}
 	AND(32, R(scratch1), Imm8(0x3F));
 	MOV(32, MDisp(dst_reg, m_dst_ofs), R(scratch1));


### PR DESCRIPTION
Most of the time when starting a game, Dolphin would throw a warning message and then Segmentation Fault, there were chances when this wouldn't happen and the game would run.
This patch makes Dolphin boot up the game consistently without crashes and warning messages.

(flacs helped figure this out)