### PR TITLE
Add soundtouch to libraries even if openal isn't installed

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -24,8 +24,12 @@ endif(AO_FOUND)
 
 if(OPENAL_FOUND)
 	set(SRCS ${SRCS} OpenALStream.cpp aldlist.cpp)
-	set(LIBS ${LIBS} ${OPENAL_LIBRARY} SoundTouch )
+	set(LIBS ${LIBS} ${OPENAL_LIBRARY})
 endif(OPENAL_FOUND)
+
+if(SOUNDTOUCH_FOUND)
+	set(LIBS ${LIBS} SoundTouch )
+endif(SOUNDTOUCH_FOUND)
 
 if(PULSEAUDIO_FOUND)
 	set(SRCS ${SRCS} PulseAudioStream.cpp)


### PR DESCRIPTION
Initially sountouch wasn't a hard requirement to build, but now it is included if openAL isn't found.

This fixes linking errors that you may encounter if you have soundtouch installed but not openAL