### PR TITLE
Change Default Buffer to 16

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -40,7 +40,7 @@ enum
 
 enum
 {
-	INITIAL_PAD_BUFFER_SIZE = 5
+	INITIAL_PAD_BUFFER_SIZE = 16
 };
 
 enum class ChatMessageType


### PR DESCRIPTION
Was 5 before the new buffer system. We then changed it to 20. It then got overwrote from merges from dolphin master I believe. But now we want it to be 16 as it is the most optimal for the default situation considering the new buffer system.