### PR TITLE
Updates Default Netplay Buffer to 16 (server)

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -97,7 +97,7 @@ NetPlayServer::NetPlayServer(const u16 port, bool traversal, const std::string& 
 		is_connected = true;
 		m_do_loop = true;
 		m_thread = std::thread(&NetPlayServer::ThreadFunc, this);
-		m_target_buffer_size = 5;
+		m_target_buffer_size = 16;
 	}
 }
 


### PR DESCRIPTION
Goes along with this commit here: https://github.com/Tinob/Ishiiruka/pull/54/commits/cdf9e75a9ea3f50975a28a56e38f07a0c22967e2

This is to make the default pad buffer for netplay "16" instead of "5".

The reason for this is with the new netplay buffer system, each buffer is 25% of what it was before - it takes 4x the buffer now for it to be equal. 16 seems to be the optimal value based on avg ping.