### PR TITLE
Fix for compilation

### DIFF
--- a/Externals/xbrz/CMakeLists.txt
+++ b/Externals/xbrz/CMakeLists.txt
@@ -9,3 +9,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 add_library(xbrz STATIC ${SRCS})
+
+if(APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()


### PR DESCRIPTION
The compilation of xBRZ needs the flag -std=c++11 which isn't correctly
passed by CMake, at least in macOS. Added it to the corresponding
CMakeLists.tex