### PR TITLE
lower case DOLPHIN_EXE_BASE for non-Apple platforms

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 if(APPLE)
 	set(DOLPHIN_EXE_BASE Ishiiruka)
 else()
-	set(DOLPHIN_EXE_BASE Ishiiruka)
+	set(DOLPHIN_EXE_BASE ishiiruka)
 endif()
 
 set(DOLPHIN_EXE ${DOLPHIN_EXE_BASE})


### PR DESCRIPTION
should lead to less confusion under Linux (case sensitive file system)