### PR TITLE
Async Shader Compilation for OpenGL

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -357,10 +357,10 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "out vec4 v_c;\n"
       "out float v_z;\n"
       "void main(void) {\n"
-      "	gl_Position = vec4(((rawpos + 0.5) / vec2(640.0, 528.0) * 2.0 - 1.0) * vec2(1.0, -1.0), 0.0, 1.0);\n"
-      "	gl_PointSize = %d.0 / 640.0;\n"
-      "	v_c = rawcolor0.bgra;\n"
-      "	v_z = float(rawcolor1 & 0xFFFFFF) / 16777216.0;\n"
+      " gl_Position = vec4(((rawpos + 0.5) / vec2(640.0, 528.0) * 2.0 - 1.0) * vec2(1.0, -1.0), 0.0, 1.0);\n"
+      " gl_PointSize = %d.0 / 640.0;\n"
+      " v_c = rawcolor0.bgra;\n"
+      " v_z = float(rawcolor1 & 0xFFFFFF) / 16777216.0;\n"
       "}\n", m_targetWidth).c_str(),
 
     StringFromFormat(
@@ -368,8 +368,8 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "in float %s_z;\n"
       "out vec4 ocol0;\n"
       "void main(void) {\n"
-      "	ocol0 = %s_c;\n"
-      "	gl_FragDepth = %s_z;\n"
+      " ocol0 = %s_c;\n"
+      " gl_FragDepth = %s_z;\n"
       "}\n", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v").c_str(),
 
     m_EFBLayers > 1 ? StringFromFormat(
@@ -381,20 +381,17 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "out float g_z;\n"
       "void main()\n"
       "{\n"
-      "	for (int j = 0; j < %d; ++j) {\n"
-      "		gl_Layer = j;\n"
-      "		gl_Position = gl_in[0].gl_Position;\n"
-      "		gl_PointSize = %d.0 / 640.0;\n"
-      "		g_c = v_c[0];\n"
-      "		g_z = v_z[0];\n"
-      "		EmitVertex();\n"
-      "		EndPrimitive();\n"
-      "	}\n"
-      "}\n", m_EFBLayers, m_EFBLayers, m_targetWidth).c_str() : nullptr);
-  while(!m_EfbPokes.finished)
-  {
-    Common::YieldCPU();
-  }
+      " for (int j = 0; j < %d; ++j) {\n"
+      "   gl_Layer = j;\n"
+      "   gl_Position = gl_in[0].gl_Position;\n"
+      "   gl_PointSize = %d.0 / 640.0;\n"
+      "   g_c = v_c[0];\n"
+      "   g_z = v_z[0];\n"
+      "   EmitVertex();\n"
+      "   EndPrimitive();\n"
+      " }\n"
+      "}\n", m_EFBLayers, m_EFBLayers, m_targetWidth).c_str() : nullptr)
+    .wait();
   glGenBuffers(1, &m_EfbPokes_VBO);
   glGenVertexArrays(1, &m_EfbPokes_VAO);
   glBindBuffer(GL_ARRAY_BUFFER, m_EfbPokes_VBO);

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -357,10 +357,10 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "out vec4 v_c;\n"
       "out float v_z;\n"
       "void main(void) {\n"
-      " gl_Position = vec4(((rawpos + 0.5) / vec2(640.0, 528.0) * 2.0 - 1.0) * vec2(1.0, -1.0), 0.0, 1.0);\n"
-      " gl_PointSize = %d.0 / 640.0;\n"
-      " v_c = rawcolor0.bgra;\n"
-      " v_z = float(rawcolor1 & 0xFFFFFF) / 16777216.0;\n"
+      "  gl_Position = vec4(((rawpos + 0.5) / vec2(640.0, 528.0) * 2.0 - 1.0) * vec2(1.0, -1.0), 0.0, 1.0);\n"
+      "  gl_PointSize = %d.0 / 640.0;\n"
+      "  v_c = rawcolor0.bgra;\n"
+      "  v_z = float(rawcolor1 & 0xFFFFFF) / 16777216.0;\n"
       "}\n", m_targetWidth).c_str(),
 
     StringFromFormat(
@@ -368,8 +368,8 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "in float %s_z;\n"
       "out vec4 ocol0;\n"
       "void main(void) {\n"
-      " ocol0 = %s_c;\n"
-      " gl_FragDepth = %s_z;\n"
+      "  ocol0 = %s_c;\n"
+      "  gl_FragDepth = %s_z;\n"
       "}\n", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v", m_EFBLayers > 1 ? "g" : "v").c_str(),
 
     m_EFBLayers > 1 ? StringFromFormat(
@@ -381,17 +381,17 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "out float g_z;\n"
       "void main()\n"
       "{\n"
-      " for (int j = 0; j < %d; ++j) {\n"
-      "   gl_Layer = j;\n"
-      "   gl_Position = gl_in[0].gl_Position;\n"
-      "   gl_PointSize = %d.0 / 640.0;\n"
-      "   g_c = v_c[0];\n"
-      "   g_z = v_z[0];\n"
-      "   EmitVertex();\n"
-      "   EndPrimitive();\n"
-      " }\n"
+      "  for (int j = 0; j < %d; ++j) {\n"
+      "    gl_Layer = j;\n"
+      "    gl_Position = gl_in[0].gl_Position;\n"
+      "    gl_PointSize = %d.0 / 640.0;\n"
+      "    g_c = v_c[0];\n"
+      "    g_z = v_z[0];\n"
+      "    EmitVertex();\n"
+      "    EndPrimitive();\n"
+      "  }\n"
       "}\n", m_EFBLayers, m_EFBLayers, m_targetWidth).c_str() : nullptr)
-    .wait();
+    .wait(); // keep these three shader compilations synchronous
   glGenBuffers(1, &m_EfbPokes_VBO);
   glGenVertexArrays(1, &m_EfbPokes_VAO);
   glBindBuffer(GL_ARRAY_BUFFER, m_EfbPokes_VBO);

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -391,6 +391,10 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
       "		EndPrimitive();\n"
       "	}\n"
       "}\n", m_EFBLayers, m_EFBLayers, m_targetWidth).c_str() : nullptr);
+  while(!m_EfbPokes.finished)
+  {
+    Common::YieldCPU();
+  }
   glGenBuffers(1, &m_EfbPokes_VBO);
   glGenVertexArrays(1, &m_EfbPokes_VAO);
   glBindBuffer(GL_ARRAY_BUFFER, m_EfbPokes_VBO);

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -182,7 +182,12 @@ bool OGLPostProcessingShader::RecompileShaders()
     vertex_shader_source += s_vertex_shader;
     std::string fragment_shader_source = header_shader_source + common_source;
     fragment_shader_source += PostProcessor::GetPassFragmentShaderSource(API_OPENGL, m_config, &pass_config);
-    if (!ProgramShaderCache::CompileShader(*shader->program, vertex_shader_source.c_str(), fragment_shader_source.c_str()))
+    ProgramShaderCache::CompileShader(*shader->program, vertex_shader_source.c_str(), fragment_shader_source.c_str());
+    while(!shader->program->finished)
+    {
+      Common::YieldCPU();
+    }
+    if (!shader->program->glprogid)
     {
       ReleasePassNativeResources(pass);
       ERROR_LOG(VIDEO, "Failed to compile post-processing shader %s (pass %s)", m_config->GetShaderName().c_str(), pass_config.entry_point.c_str());
@@ -209,7 +214,12 @@ bool OGLPostProcessingShader::RecompileShaders()
       vertex_shader_source += s_layered_vertex_shader;
       std::string geometry_shader_source = StringFromFormat(s_geometry_shader, m_internal_layers * 3, m_internal_layers).c_str();
 
-      if (!ProgramShaderCache::CompileShader(*shader->gs_program, vertex_shader_source.c_str(), fragment_shader_source.c_str(), geometry_shader_source.c_str()))
+      ProgramShaderCache::CompileShader(*shader->gs_program, vertex_shader_source.c_str(), fragment_shader_source.c_str(), geometry_shader_source.c_str());
+      while(!shader->gs_program->finished)
+      {
+        Common::YieldCPU();
+      }
+      if (!shader->gs_program->glprogid)
       {
         ReleasePassNativeResources(pass);
         ERROR_LOG(VIDEO, "Failed to compile GS post-processing shader %s (pass %s)", m_config->GetShaderName().c_str(), pass_config.entry_point.c_str());

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -182,12 +182,9 @@ bool OGLPostProcessingShader::RecompileShaders()
     vertex_shader_source += s_vertex_shader;
     std::string fragment_shader_source = header_shader_source + common_source;
     fragment_shader_source += PostProcessor::GetPassFragmentShaderSource(API_OPENGL, m_config, &pass_config);
-    ProgramShaderCache::CompileShader(*shader->program, vertex_shader_source.c_str(), fragment_shader_source.c_str());
-    while(!shader->program->finished)
-    {
-      Common::YieldCPU();
-    }
-    if (!shader->program->glprogid)
+    if (!ProgramShaderCache::CompileShader(
+            *shader->program, vertex_shader_source.c_str(), fragment_shader_source.c_str())
+            .get())
     {
       ReleasePassNativeResources(pass);
       ERROR_LOG(VIDEO, "Failed to compile post-processing shader %s (pass %s)", m_config->GetShaderName().c_str(), pass_config.entry_point.c_str());
@@ -214,12 +211,11 @@ bool OGLPostProcessingShader::RecompileShaders()
       vertex_shader_source += s_layered_vertex_shader;
       std::string geometry_shader_source = StringFromFormat(s_geometry_shader, m_internal_layers * 3, m_internal_layers).c_str();
 
-      ProgramShaderCache::CompileShader(*shader->gs_program, vertex_shader_source.c_str(), fragment_shader_source.c_str(), geometry_shader_source.c_str());
-      while(!shader->gs_program->finished)
-      {
-        Common::YieldCPU();
-      }
-      if (!shader->gs_program->glprogid)
+      if (!ProgramShaderCache::CompileShader(
+              *shader->gs_program, vertex_shader_source.c_str(),
+              fragment_shader_source.c_str(),
+              geometry_shader_source.c_str())
+              .get())
       {
         ReleasePassNativeResources(pass);
         ERROR_LOG(VIDEO, "Failed to compile GS post-processing shader %s (pass %s)", m_config->GetShaderName().c_str(), pass_config.entry_point.c_str());

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -337,6 +337,11 @@ SHADER* ProgramShaderCache::SetShader(PIXEL_SHADER_RENDER_MODE render_mode)
 
   if (!g_ActiveConfig.bFullAsyncShaderCompilation)
   {
+    // We should not use the value held by the future get() to determine whether or not the shader
+    // was successfully compiled. We check for the existence of glprogid on the shader instead, see
+    // below. This is because the future in last_future may not actually correspond to the current
+    // PrepareShader/SetShader pairing. However it is correct that if the future in last_future is
+    // ready, then we can proceed. See comment above in PrepareShader.
     last_future[render_mode].wait();
   }
   PCacheEntry* entry = last_entry[render_mode];

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -677,7 +677,7 @@ void ProgramShaderCache::Init()
   }
   if (g_ActiveConfig.backend_info.bSupportsUberShaders)
   {
-    // CompileUberShaders();
+    CompileUberShaders();
   }
   CurrentProgram = 0;
   last_entry.fill(nullptr);
@@ -983,7 +983,7 @@ void ProgramShaderCache::Reload()
   CompileShaders();
   if (g_ActiveConfig.backend_info.bSupportsUberShaders)
   {
-    // CompileUberShaders();
+    CompileUberShaders();
   }
 }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -311,7 +311,15 @@ void ProgramShaderCache::PrepareShader(
   GFX_DEBUGGER_PAUSE_AT(NEXT_PIXEL_SHADER_CHANGE, true);
 
   if (newentry.shader.started)
+  {
+    // Conveniently we don't need to do anything to last_future in this case.
+    // With asynchronous shaders last_future doesn't matter.
+    // With synchronous shaders, we can't be here unless the cached shader has already finished
+    // compiling. Therefore we should set last_future to an immediately available future. However
+    // we also can't be here unless the current value of last_future is already available so we
+    // don't need to do anything.
     return;
+  }
 
   // schedule shader compilation
   newentry.in_cache = false;
@@ -684,6 +692,7 @@ void ProgramShaderCache::Init()
   last_uber_entry = nullptr;
   last_uid = {};
   last_uber_uid = {};
+  last_future = {};
   InvalidateVertexFormat();
 }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -745,7 +745,7 @@ void ProgramShaderCache::CompileShadersAsync() {
   }
 
   std::unique_ptr<QueueEntry> entry;
-  while(1)
+  while(true)
   {
     {
       std::unique_lock<std::mutex> lock(s_mutex);

--- a/Source/Core/VideoBackends/OGL/RasterFont.cpp
+++ b/Source/Core/VideoBackends/OGL/RasterFont.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/Common.h"
 #include "Common/GL/GLUtil.h"
+#include "Common/Thread.h"
 
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/RasterFont.h"
@@ -161,6 +162,10 @@ RasterFont::RasterFont()
 
   // generate shader
   ProgramShaderCache::CompileShader(s_shader, s_vertexShaderSrc, s_fragmentShaderSrc);
+  while(!s_shader.finished)
+  {
+    Common::YieldCPU();
+  }
   s_shader.Bind();
 
   // bound uniforms

--- a/Source/Core/VideoBackends/OGL/RasterFont.cpp
+++ b/Source/Core/VideoBackends/OGL/RasterFont.cpp
@@ -6,7 +6,6 @@
 
 #include "Common/Common.h"
 #include "Common/GL/GLUtil.h"
-#include "Common/Thread.h"
 
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/RasterFont.h"
@@ -161,11 +160,7 @@ RasterFont::RasterFont()
     GL_RGBA, GL_UNSIGNED_BYTE, texture_data.data());
 
   // generate shader
-  ProgramShaderCache::CompileShader(s_shader, s_vertexShaderSrc, s_fragmentShaderSrc);
-  while(!s_shader.finished)
-  {
-    Common::YieldCPU();
-  }
+  ProgramShaderCache::CompileShader(s_shader, s_vertexShaderSrc, s_fragmentShaderSrc).wait();
   s_shader.Bind();
 
   // bound uniforms

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -318,7 +318,7 @@ bool TextureCache::CompileShaders()
       StringFromFormat(VProgram, prefix, prefix).c_str(),
       StringFromFormat(pDepthMatrixProg, depth_layer).c_str(),
       GProgram)
-      .wait();
+      .wait(); // keep these three shader compilations synchronous
   bool compiled =
       s_ColorCopyProgram.glprogid && s_ColorMatrixProgram.glprogid && s_DepthMatrixProgram.glprogid;
 
@@ -428,7 +428,7 @@ bool TextureCache::CompileShaders()
         StringFromFormat(VProgram, prefix, prefix).c_str(),
         ("#define DECODE DecodePixel_RGB5A3" + palette_shader).c_str(),
         GProgram)
-        .wait();
+        .wait(); // keep these three shader compilations synchronous
 
     s_palette_buffer_offset_uniform[GX_TL_IA8] =
         glGetUniformLocation(s_palette_pixel_shader[GX_TL_IA8].glprogid, "texture_buffer_offset");

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -276,9 +276,9 @@ bool TextureCache::CompileShaders()
     "uniform vec4 copy_position;\n" // left, top, right, bottom
     "void main()\n"
     "{\n"
-    " vec2 rawpos = vec2(gl_VertexID&1, gl_VertexID&2);\n"
-    " %s_uv0 = vec3(mix(copy_position.xy, copy_position.zw, rawpos) / vec2(textureSize(samp9, 0).xy), 0.0);\n"
-    " gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
+    "  vec2 rawpos = vec2(gl_VertexID&1, gl_VertexID&2);\n"
+    "  %s_uv0 = vec3(mix(copy_position.xy, copy_position.zw, rawpos) / vec2(textureSize(samp9, 0).xy), 0.0);\n"
+    "  gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
     "}\n";
 
   const char *GProgram = g_ActiveConfig.iStereoMode > 0 ?
@@ -317,11 +317,8 @@ bool TextureCache::CompileShaders()
       s_DepthMatrixProgram,
       StringFromFormat(VProgram, prefix, prefix).c_str(),
       StringFromFormat(pDepthMatrixProg, depth_layer).c_str(),
-      GProgram);
-  while(!s_DepthMatrixProgram.finished)
-  {
-    Common::YieldCPU();
-  }
+      GProgram)
+      .wait();
   bool compiled =
       s_ColorCopyProgram.glprogid && s_ColorMatrixProgram.glprogid && s_DepthMatrixProgram.glprogid;
 
@@ -430,11 +427,8 @@ bool TextureCache::CompileShaders()
         s_palette_pixel_shader[GX_TL_RGB5A3],
         StringFromFormat(VProgram, prefix, prefix).c_str(),
         ("#define DECODE DecodePixel_RGB5A3" + palette_shader).c_str(),
-        GProgram);
-    while (!s_palette_pixel_shader[GX_TL_RGB5A3].finished)
-    {
-      Common::YieldCPU();
-    }
+        GProgram)
+        .wait();
 
     s_palette_buffer_offset_uniform[GX_TL_IA8] =
         glGetUniformLocation(s_palette_pixel_shader[GX_TL_IA8].glprogid, "texture_buffer_offset");

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -99,11 +99,8 @@ static void CreatePrograms()
     "	vec4 const3 = vec4(0.0625,0.5,0.0625,0.5);\n"
     "	ocol0 = vec4(dot(c1,y_const),dot(c01,u_const),dot(c0,y_const),dot(c01, v_const)) + const3;\n"
     "}\n";
-  ProgramShaderCache::CompileShader(s_rgbToYuyvProgram, VProgramRgbToYuyv, FProgramRgbToYuyv);
-  while (!s_rgbToYuyvProgram.finished)
-  {
-    Common::YieldCPU();
-  }
+  ProgramShaderCache::CompileShader(s_rgbToYuyvProgram, VProgramRgbToYuyv, FProgramRgbToYuyv)
+      .wait();
   s_rgbToYuyvUniform_loc = glGetUniformLocation(s_rgbToYuyvProgram.glprogid, "copy_position");
 
   /* TODO: Accuracy Improvements
@@ -138,11 +135,8 @@ static void CreatePrograms()
     "		yComp + (2.018 * uComp),\n"
     "		1.0);\n"
     "}\n";
-  ProgramShaderCache::CompileShader(s_yuyvToRgbProgram, VProgramYuyvToRgb, FProgramYuyvToRgb);
-  while (!s_yuyvToRgbProgram.finished)
-  {
-    Common::YieldCPU();
-  }
+  ProgramShaderCache::CompileShader(s_yuyvToRgbProgram, VProgramYuyvToRgb, FProgramYuyvToRgb)
+      .wait();
 }
 
 static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
@@ -171,12 +165,7 @@ static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
     "}\n";
 
   EncodingProgram program;
-  ProgramShaderCache::CompileShader(program.program, VProgram, shader);
-  while (!program.program.finished)
-  {
-    Common::YieldCPU();
-  }
-  if (!program.program.glprogid)
+  if (!ProgramShaderCache::CompileShader(program.program, VProgram, shader).get())
     PanicAlert("Failed to compile texture encoding shader.");
 
   program.copy_position_uniform = glGetUniformLocation(program.program.glprogid, "position");

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -100,6 +100,10 @@ static void CreatePrograms()
     "	ocol0 = vec4(dot(c1,y_const),dot(c01,u_const),dot(c0,y_const),dot(c01, v_const)) + const3;\n"
     "}\n";
   ProgramShaderCache::CompileShader(s_rgbToYuyvProgram, VProgramRgbToYuyv, FProgramRgbToYuyv);
+  while (!s_rgbToYuyvProgram.finished)
+  {
+    Common::YieldCPU();
+  }
   s_rgbToYuyvUniform_loc = glGetUniformLocation(s_rgbToYuyvProgram.glprogid, "copy_position");
 
   /* TODO: Accuracy Improvements
@@ -135,6 +139,10 @@ static void CreatePrograms()
     "		1.0);\n"
     "}\n";
   ProgramShaderCache::CompileShader(s_yuyvToRgbProgram, VProgramYuyvToRgb, FProgramYuyvToRgb);
+  while (!s_yuyvToRgbProgram.finished)
+  {
+    Common::YieldCPU();
+  }
 }
 
 static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
@@ -163,7 +171,12 @@ static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
     "}\n";
 
   EncodingProgram program;
-  if (!ProgramShaderCache::CompileShader(program.program, VProgram, shader))
+  ProgramShaderCache::CompileShader(program.program, VProgram, shader);
+  while (!program.program.finished)
+  {
+    Common::YieldCPU();
+  }
+  if (!program.program.glprogid)
     PanicAlert("Failed to compile texture encoding shader.");
 
   program.copy_position_uniform = glGetUniformLocation(program.program.glprogid, "position");

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -118,7 +118,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsValidationLayer = false;
   g_Config.backend_info.bSupportsReversedDepthRange = true;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = true;
-  g_Config.backend_info.bSupportsAsyncShaderCompilation = false;
+  g_Config.backend_info.bSupportsAsyncShaderCompilation = true;
   g_Config.backend_info.bSupportsUberShaders = true;
   g_Config.backend_info.Adapters.clear();
 


### PR DESCRIPTION
OpenGL doesn't have good driver support for parallel shader compilations, so implementing async shader compilation the same way as D3D is not possible. Instead:

- Create a shader compilation thread. 
- Add shader code to be compiled to a queue.
- Consume that queue from the shader compilation thread and compile shaders synchronously.