### PR TITLE
Fix "Fast EFB Access" dialog behavior when toggling "Skip EFB Access"

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -1923,7 +1923,7 @@ void VideoConfigDiag::OnUpdateUI(wxUpdateUIEvent& ev)
   borderless_fullscreen->Show((vconfig.backend_info.APIType & API_D3D9) == 0);
 #endif
   // EFB Access Cache
-  Fast_efb_cache->Show(vconfig.bEFBAccessEnable);
+  Fast_efb_cache->Enable(vconfig.bEFBAccessEnable);
   // XFB
   virtual_xfb->Enable(vconfig.bUseXFB);
   real_xfb->Enable(vconfig.bUseXFB);


### PR DESCRIPTION
This PR fixes odd behavior when toggling "Skip EFB Access" to ON, closing video config dialog, re-opening video config dialog, and toggling "Skip EFB Access" to OFF.