### PR TITLE
Replace geckocodes.org with mirror codes.rc24.xyz

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -30,7 +30,9 @@ std::vector<GeckoCode> DownloadCodes(std::string gameid, bool* succeeded)
     break;
   }
 
-  std::string endpoint{"http://geckocodes.org/txt.php?txt=" + gameid};
+  // codes.rc24.xyz is a mirror of the now defunct geckocodes.org.
+  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + gametdb_id};
+
   Common::HttpRequest http;
   const Common::HttpRequest::Response response = http.Get(endpoint);
   *succeeded = response.has_value();


### PR DESCRIPTION
Implemented this change from vanilla Dolphin: https://github.com/dolphin-emu/dolphin/pull/9133

If you are unaware, geckocodes.org has shutdown, making the Gecko codes downloader broken. This PR replaces it with the mirror codes.rc24.xyz.