### PR TITLE
GeckoCodeConfig: Use correct variable name

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -31,7 +31,7 @@ std::vector<GeckoCode> DownloadCodes(std::string gameid, bool* succeeded)
   }
 
   // codes.rc24.xyz is a mirror of the now defunct geckocodes.org.
-  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + gametdb_id};
+  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + gameid};
 
   Common::HttpRequest http;
   const Common::HttpRequest::Response response = http.Get(endpoint);


### PR DESCRIPTION
When I proposed the change I failed to use the correct variable and stupidly assumed the class hadn't been changed much. They refactored the variable names since then and this was one of them.

This was a pretty silly mistake on my part.

I have ensured this does work as intended.