### PR TITLE
Added additional options relating to EFB copies

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -119,6 +119,10 @@ protected:
   void Event_ScalingShader(wxCommandEvent& ev);
   void Event_ConfigureScalingShader(wxCommandEvent &ev);
   void Event_StereoShader(wxCommandEvent& ev);
+  void Event_EfbMinSlider(wxCommandEvent& ev);
+
+  void Event_EfbExcludeMinSlider(wxCommandEvent& ev);
+  void Event_EfbExcludeMaxSlider(wxCommandEvent& ev);
 
   void Event_StereoDepth(wxCommandEvent &ev);
   void Event_TessellationDistance(wxCommandEvent &ev);
@@ -194,6 +198,9 @@ protected:
   SettingCheckBox* hp_frame_buffer;
   SettingCheckBox* sim_bump;
   wxStaticText* label_TextureScale;
+  wxStaticText* label_EfbMinScale;
+  wxStaticText* label_EfbScaleExcludeMin;
+  wxStaticText* label_EfbScaleExcludeMax;
   SettingCheckBox* borderless_fullscreen;
   RefBoolSetting<wxCheckBox>* render_to_main_checkbox;
 
@@ -230,6 +237,7 @@ protected:
   wxChoice* choice_stereoshader;
   wxStaticBoxSizer* group_phong;
   wxStaticBoxSizer* group_Tessellation;
+  wxStaticBoxSizer* group_efb_options;
 
   wxSlider* bump_strenght_slider;
   wxSlider* bump_threshold_slider;

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -610,6 +610,7 @@ protected:
 
   // Projection state for detecting when to apply post
   PROJECTION_STATE m_projection_state = PROJECTION_STATE_INITIAL;
+  int m_efb_counter = 0;
 
   // Global post-processing enable state
   bool m_active = false;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1451,7 +1451,12 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, u32 dstFormat, u32
   u32 scaled_tex_w = tex_w;
   u32 scaled_tex_h = tex_h;
 
-  if (g_ActiveConfig.bCopyEFBScaled)
+  if (g_ActiveConfig.bCopyEFBScaled
+      && (float) tex_w >= (float)g_ActiveConfig.iEFBScaledExcludeMin*(float)g_renderer->GetTargetRectangle().GetWidth()/200.0
+      && (float) tex_h >= (float)g_ActiveConfig.iEFBScaledExcludeMin*(float)g_renderer->GetTargetRectangle().GetHeight()/200.0
+      ||((float) tex_w <= (float)g_ActiveConfig.iEFBScaledExcludeMax*(float)g_renderer->GetTargetRectangle().GetWidth()/200.0
+      || (float) tex_h <= (float)g_ActiveConfig.iEFBScaledExcludeMax*(float)g_renderer->GetTargetRectangle().GetHeight()/200.0
+    ))
   {
     scaled_tex_w = g_renderer->EFBToScaledX(tex_w);
     scaled_tex_h = g_renderer->EFBToScaledY(tex_h);


### PR DESCRIPTION
### Added EFB Filter Options for postprocessing
When the postprocess trigger is set to "On EFB Copy" an additional section of options will be visible.
![image](https://user-images.githubusercontent.com/12588584/137066702-ca3140ed-32e5-44c5-a242-8fea76104c4b.png)
These options allow more specificity on which EFB copies postprocessing is actually applied to.
- Must be perspective camera: On by default, allows you to disable the perspective camera check
- Must match screen aspect ratio: Off by default, only allows EFB copies that exactly match the aspect ratio of the render resolution.
- Minimum Resolution %: Only allows EFB copies with a width and height that are higher than this percentage of the render resolution
- Copy Index Filter: Can be set to only allow the second, third, or fourth EFB copy each frame. Useful for games that copy the screen multiple times, otherwise post processing would be applied multiple times per frame
- Use "On Swap" as failsafe: On by default, Allows you to disable the built in failsafe that will apply postprocessing at the end of a frame if no valid EFB copies are found. Useful for games that sometimes render only in 2D

### Added Conditional EFB Scaling (Fixes bloom in most games!)
Refer to this thread for practical uses: https://forums.dolphin-emu.org/Thread-conditional-efb-scaling-to-fix-bloom
The code I used in not the same, but has the same result.

![image](https://user-images.githubusercontent.com/12588584/137067304-4e89c9e5-103d-485b-a03a-95d498f855c9.png)
The default behaviour is unchanged, by changing "Scale EFB Copies Above," EFB copies smaller than that percentage of the render res will be excluded. (For example, bloom)
"Also Scale EFB Copies Below" gives the option to allow EFB Copies below a certain threshold, useful if the first option is needed to fix bloom, but small efb copies are used by the game elsewhere.
